### PR TITLE
Fix Bin/Hex parsing of BigInteger for powers of 2

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -466,9 +466,9 @@ namespace System
             if (value.IsEmpty)
             {
                 // There's nothing beyond significant leading block. Return it as the result.
-                if ((int)(leading ^ signBits) < 0 || (int)leading == int.MinValue)
+                if ((int)(leading ^ signBits) < 0)
                 {
-                    // The sign of result differs with leading digit, or it's int.MinValue.
+                    // The sign of result differs with leading digit.
                     // Require to store in _bits.
                     result = new BigInteger((int)signBits | 1, [leading]);
                     return ParsingStatus.OK;
@@ -476,7 +476,7 @@ namespace System
                 else
                 {
                     // Small value that fits in _sign.
-                    result = new BigInteger((int)leading, null);
+                    result = new BigInteger((int)leading);
                     return ParsingStatus.OK;
                 }
             }

--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -470,12 +470,23 @@ namespace System
                 {
                     // The sign of result differs with leading digit.
                     // Require to store in _bits.
-                    result = new BigInteger((int)signBits | 1, [leading]);
+                    if ((int)signBits < 0)
+                    {
+                        // Negative value
+                        result = leading == 0
+                            ? new BigInteger(-1, [leading, 1u])
+                            : new BigInteger(-1, [unchecked((uint)-(int)leading)]);
+                    }
+                    else
+                    {
+                        // Positive value
+                        result = new BigInteger(1, [leading]);
+                    }
                     return ParsingStatus.OK;
                 }
                 else
                 {
-                    // Small value that fits in _sign.
+                    // Small value that fits in Int32.
                     result = new BigInteger((int)leading);
                     return ParsingStatus.OK;
                 }
@@ -505,13 +516,24 @@ namespace System
             if (signBits != 0)
             {
                 // For negative values, negate the whole array
-                NumericsHelpers.DangerousMakeTwosComplement(bits);
+                Span<uint> trimmed = new Span<uint>(bits).TrimStart(0u);
+                if (trimmed.Length == 0)
+                {
+                    bits = new uint[bits.Length + 1];
+                    bits[^1] = 1;
+                }
+                else
+                {
+                    NumericsHelpers.DangerousMakeTwosComplement(trimmed);
+                }
 
                 result = new BigInteger(-1, bits);
                 return ParsingStatus.OK;
             }
             else
             {
+                Debug.Assert(leading != 0);
+
                 // For positive values, it's done
                 result = new BigInteger(1, bits);
                 return ParsingStatus.OK;

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -146,6 +146,13 @@ namespace System.Numerics.Tests
             Assert.True(BigInteger.TryParse("F", NumberStyles.HexNumber, null, out result));
             Assert.Equal(-1, result);
 
+            for (int i = 0; i < 40; i++)
+            {
+                string test = "F" + new string('0', i);
+                Assert.True(BigInteger.TryParse(test, NumberStyles.HexNumber, null, out result));
+                Assert.Equal(BigInteger.MinusOne << (4 * i), result);
+            }
+
             Assert.Throws<FormatException>(() =>
             {
                 BigInteger.Parse("zzz", NumberStyles.HexNumber);
@@ -476,6 +483,12 @@ namespace System.Numerics.Tests
             for (int i = 0; i < s_samples; i++)
             {
                 VerifyParseToString(GetBinaryDigitSequence(1, 100, random) + GetRandomInvalidChar(random) + GetBinaryDigitSequence(1, 10, random), ns, false);
+            }
+
+            // Power of 2
+            for (int i = 0; i < 70; i++)
+            {
+                VerifyParseToString("1" + new string('0', i), ns, true);
             }
         }
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/95543#issuecomment-1908688718

I fixed Bin/Hex parsing of BigInteger for powers of 2.

```cs
// -1 << 32
BigInteger.Parse("100000000000000000000000000000000", NumberStyles.BinaryNumber);
BigInteger.Parse("F00000000", NumberStyles.HexNumber);

// -1 << 64
BigInteger.Parse("10000000000000000000000000000000000000000000000000000000000000000", NumberStyles.BinaryNumber);
BigInteger.Parse("F0000000000000000", NumberStyles.HexNumber);
```